### PR TITLE
fix horizontal overscroll

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -92,7 +92,7 @@ export default async function RootLayout({
         />
       </head>
       <body
-        className={`${inter.variable} ${spaceGrotesk.variable} ${jetBrainsMono.variable} bg-dark-200 flex min-h-screen flex-col font-sans text-white antialiased`}
+        className={`${inter.variable} ${spaceGrotesk.variable} ${jetBrainsMono.variable} bg-dark-200 flex min-h-screen flex-col overflow-x-hidden font-sans text-white antialiased`}
       >
         <ServiceWorkerRegistration />
         <HeaderWrapper />


### PR DESCRIPTION
## Summary
- add `overflow-x-hidden` to `<body>` classes to prevent horizontal scrolling on mobile

## Testing
- `npm run lint`
- *(no tests configured)*