### PR TITLE
Fix mobile fullscreen video loop

### DIFF
--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -42,7 +42,9 @@ export const VideoPlayer = ({
         (document as Document & { webkitFullscreenElement?: Element })
           .webkitFullscreenElement ||
         (document as Document & { msFullscreenElement?: Element })
-          .msFullscreenElement;
+          .msFullscreenElement ||
+        (video as HTMLVideoElement & { webkitDisplayingFullscreen?: boolean })
+          .webkitDisplayingFullscreen;
 
       if (!isFullscreen && video.currentTime >= 58) {
         video.currentTime = 0;


### PR DESCRIPTION
## Summary
- avoid looping when the video is full screen on iOS Safari by checking `webkitDisplayingFullscreen`

## Testing
- `npm run lint`
- `npm run format`
- `npm run type-check`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683991850dd4832ab6c624f8fe66c919