### PR TITLE
content(future): fix quote; abundance is an allocation outcome, not a mistake

### DIFF
--- a/src/app/future/page.tsx
+++ b/src/app/future/page.tsx
@@ -156,7 +156,7 @@ export default function FuturePage() {
           className="from-brand-cyan/10 via-brand-pink/10 to-brand-amber/10 border-brand-pink/20 mb-12 rounded-lg border bg-gradient-to-r p-8 text-center"
         >
           <blockquote className="mb-2 text-lg italic">
-            &quot;Abundance is not a dream—just a poorly allocated budget.&quot;
+            &quot;Abundance is not a dream—just a well-allocated budget away.&quot;
           </blockquote>
           <cite className="text-sm text-white/60">
             — 2040 Annual Report, we hope


### PR DESCRIPTION
Original phrasing (“…just a poorly allocated budget”) unintentionally contradicts the message by tying abundance to poor allocation. Replace with “Abundance is not a dream—just a well-allocated budget away.” to keep the punchy cadence while restoring the intended logic: scarcity stems from allocation, not absolute lack.

Reference location: Future page hero section. https://justevery.com/future